### PR TITLE
Correct name of repo

### DIFF
--- a/build-deploy-github-pages.yml
+++ b/build-deploy-github-pages.yml
@@ -55,3 +55,5 @@ steps:
     displayName: "Publish: GitHub Pages"
     workingDirectory: $(working_directory)
     condition: and(contains(variables['build.sourceBranch'], 'refs/heads/master'), succeeded())
+    env:
+      DEPLOYMENT_BRANCH: master

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ const config = {
   onBrokenLinks: "warn",
   favicon: "img/icons/favicon.ico",
   organizationName: "Ensono", // Usually your GitHub org/user name.
-  projectName: "Ensono Stacks", // Usually your repo name.
+  projectName: "amido.github.io", // Usually your repo name.
   customFields: {
     description: 'Ensono Stacks is a catalogue of workload templates that\n' +
         'instantly scaffold and deploy boilerplate software projects. Slash the time it takes to get productive on your software project.',


### PR DESCRIPTION
#### 📲 What

Corrected the name of the repo in the Docusarus.

Specified the name of the trunk branch in the ADO pipeline file.

#### 🤔 Why
		
During the rename of `amido` to `ensono` it looks like the name of the respository was incorrectly changed. This meant that when the publish occurs, an incorrect repository is attempted to be cloned.

Docusaarus does not set the trunk brancch by default anymore so needed to have `master` explicitly set.
		
#### 🛠 How
		
Modified the name `Ensono Stacks` to `amido.github.io`.

Added `DEPLOYMENT_BRANCH` as an environment variable for the Bash task in the ADO pipeline.

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR.
		 
#### 🕵️ How to test

Notes on how a reviewer can test the changes, e.g. how to run the tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
