### PR TITLE
7568 chore: Update .NET version to 8 in code and documentation

### DIFF
--- a/asciidoc/stackscli/examples.adoc
+++ b/asciidoc/stackscli/examples.adoc
@@ -79,7 +79,7 @@ The following table shows the additional options that are required when scaffold
 | Framework being used, e.g. dotnet, java, or infra
 
 | framework_version
-| v6.0.274
+| v8.0.101
 | Version of the framework option to grab.
 |===
 
@@ -90,13 +90,13 @@ Run the following command to create the new project in the working directory, wh
 .Bash
 [%nowrap,bash]
 ----
-stacks-cli scaffold -A core \ --company MyCompany \ --component backend \ --domain stacks-example.com \ -F dotnet \ -n my-webapi \ -p azdo \ -P aks \ --tfcontainer my-webapi \ --tfgroup supporting-group \ --tfstorage kjh56sdfnjnkjn \ -O webapi \ -V v6.0.274 \ --cmdlog
+stacks-cli scaffold -A core \ --company MyCompany \ --component backend \ --domain stacks-example.com \ -F dotnet \ -n my-webapi \ -p azdo \ -P aks \ --tfcontainer my-webapi \ --tfgroup supporting-group \ --tfstorage kjh56sdfnjnkjn \ -O webapi \ -V v8.0.101 \ --cmdlog
 ----
 
 .Powershell
 [%nowrap,powershell]
 ----
-stacks-cli scaffold -A core ` --company MyCompany ` --component backend ` --domain stacks-example.com ` -F dotnet ` -n my-webapi ` -p azdo ` -P aks ` --tfcontainer my-webapi ` --tfgroup supporting-group ` --tfstorage kjh56sdfnjnkjn ` -O webapi ` -V v6.0.274 ` --cmdlog
+stacks-cli scaffold -A core ` --company MyCompany ` --component backend ` --domain stacks-example.com ` -F dotnet ` -n my-webapi ` -p azdo ` -P aks ` --tfcontainer my-webapi ` --tfgroup supporting-group ` --tfstorage kjh56sdfnjnkjn ` -O webapi ` -V v8.0.101 ` --cmdlog
 ----
 
 This will get the specified version of the framework project, create a new project based on the options specified, and then update the build files to work with those settings. Finally, it will initialize a new git repository in the new project directory. All of the commands that have been run by the CLI will be saved in the `cmdlog.txt` file in the directory that the command was run in.
@@ -107,6 +107,7 @@ image::./images/example_dotnet_webapi_cmdline.png[CLI with command line options]
 <<cli-with-command-line-options, Figure 1>> shows the output of the command running in PowerShell. It also shows the commands that have been run in the `cmdlog.txt`.
 
 The resultant project, as stated by the `Project path:` statement in the screenshot, contains all the necessary files to run a simple .NET WebApi. The following listing shows that the solutions have been renamed with the `company` name as the namespace.
+
 
 ----
 └───my-webapi

--- a/asciidoc/stackscli/examples.adoc
+++ b/asciidoc/stackscli/examples.adoc
@@ -801,7 +801,7 @@ stacks:
       id: stacks-dotnet
     cqrs:
       type: nuget
-      name: Amido.Stacks.CQRS.Templates
+      name: Amido.Stacks.Templates
       id: stacks-dotnet-cqrs
   java:
     webapi:
@@ -905,7 +905,7 @@ stacks:
       id: stacks-dotnet
     cqrs:
       type: nuget
-      name: Amido.Stacks.CQRS.Templates
+      name: Amido.Stacks.Templates
       id: stacks-dotnet-cqrs
   java:
     webapi:

--- a/asciidoc/workloads/azure/backend/netcore/introduction_netcore.adoc
+++ b/asciidoc/workloads/azure/backend/netcore/introduction_netcore.adoc
@@ -1,6 +1,6 @@
 ---
 id: introduction_netcore
-title: Introduction to the .NET 6 REST API application
+title: Introduction to the .NET 8 REST API application
 linkTitle: Introduction
 weight: 1
 keywords:
@@ -13,7 +13,7 @@ keywords:
   - cosmos db
 ---
 
-Ensono Stacks is a collection of sample .NET 6 template projects that contain:
+Ensono Stacks is a collection of sample .NET 8 template projects that contain:
 
 - Simple Web API application
 - A Web API application with CQRS functionality

--- a/asciidoc/workloads/azure/backend/netcore/quickstart/web_api_cqrs/create_project_netcore.adoc
+++ b/asciidoc/workloads/azure/backend/netcore/quickstart/web_api_cqrs/create_project_netcore.adoc
@@ -151,7 +151,7 @@ If you want to remove the templates from your system you'll have to uninstall th
 .To uninstall package execute the following command
 [source, bash]
 ----
-dotnet new uninstall Amido.Stacks.CQRS.Templates
+dotnet new uninstall Amido.Stacks.Templates
 ----
 =====
 

--- a/asciidoc/workloads/azure/backend/netcore/requirements_netcore.adoc
+++ b/asciidoc/workloads/azure/backend/netcore/requirements_netcore.adoc
@@ -31,7 +31,7 @@ keywords:
 
 [discrete]
 ==== Mandatory
-* link:https://dotnet.microsoft.com/en-us/download/dotnet/6.0[.NET 6 SDK] and Runtime 6.0.* or superior (for .NET 6 templates)
+* link:https://dotnet.microsoft.com/en-us/download/dotnet/8.0[.NET 8 SDK] and Runtime .0.* or superior (for .NET 8 templates)
 * link:https://aka.ms/cosmosdb-emulator[CosmosDB Emulator 2.4.5+]
 
 [discrete]
@@ -70,7 +70,7 @@ keywords:
 
 * homebrew
 * azure-cli: brew install azure-cli
-* link:https://dotnet.microsoft.com/en-us/download/dotnet/6.0[.NET 6 SDK] 6.0.* or superior: brew cask install dotnet-sdk
+* link:https://dotnet.microsoft.com/en-us/download/dotnet/8.0[.NET 8 SDK] 8.0.* or superior: brew cask install dotnet-sdk
 * link:https://aka.ms/cosmosdb-emulator[CosmosDB Emulator 2.4.5+]: Currently the Cosmos emulator can only be run on Windows. If you have an Azure subscription, you are able to use the Azure version instead
 
 [discrete]
@@ -80,4 +80,4 @@ keywords:
 * kubectl: docker run --name kubectl bitnami/kubectl:latest
 =====
 
-NOTE: The current version of Ensono Stacks are templates for .NET 6 (Current LTS, recommended).
+NOTE: The current version of Ensono Stacks are templates for .NET 8 (Current LTS, recommended).

--- a/docs/stackscli/examples.mdx
+++ b/docs/stackscli/examples.mdx
@@ -1189,8 +1189,8 @@ stacks:
       id: stacks-dotnet
     cqrs:
       type: nuget
-      name: Amido.Stacks.CQRS.Templates
-      id: stacks-dotnet-cqrs
+      name: Amido.Stacks.Templates
+      id: stacks-dotnet
   java:
     webapi:
       version: master
@@ -1288,8 +1288,8 @@ stacks:
       id: stacks-dotnet
     cqrs:
       type: nuget
-      name: Amido.Stacks.CQRS.Templates
-      id: stacks-dotnet-cqrs
+      name: Amido.Stacks.Templates
+      id: stacks-dotnet
   java:
     webapi:
       version: master

--- a/docs/stackscli/examples.mdx
+++ b/docs/stackscli/examples.mdx
@@ -201,7 +201,7 @@ The following table shows the additional options that are required when scaffold
 | Name              | Value      | Description                                            |
 | ----------------- | ---------- | ------------------------------------------------------ |
 | framework         | `dotnet`   | Framework being used, e.g. `dotnet`, `java` or `infra` |
-| framework_version | `v6.0.274` | Version of the framework option to grab.               |
+| framework_version | `v8.0.101` | Version of the framework option to grab.               |
 
 .NET Specific settings
 
@@ -275,7 +275,7 @@ Run the following command to create the new project in the working directory, wh
               </a>
               <a className="sourceLine" id="cb1-13" title="13">
                 {" "}
-                -V v6.0.274 \
+                -V v8.0.101 \
               </a>
               <a className="sourceLine" id="cb1-14" title="14">
                 {" "}

--- a/docs/workloads/azure/backend/netcore/introduction_netcore.md
+++ b/docs/workloads/azure/backend/netcore/introduction_netcore.md
@@ -1,10 +1,10 @@
 ---
 id: introduction_netcore
-title: Introduction to the .NET 6 REST API application
+title: Introduction to the .NET 8 REST API application
 sidebar_label: Introduction
 hide_title: false
 hide_table_of_contents: true
-description: Introduction to .NET 6 REST API application with CQRS
+description: Introduction to .NET 8 REST API application with CQRS
 keywords:
   - .net core
   - rest api
@@ -17,7 +17,7 @@ keywords:
 
 import HideNavigation  from "../../../../../src/components/HideNavigation/HideNavigation";
 
-Ensono Stacks is a collection of sample .NET 6 template projects that contain
+Ensono Stacks is a collection of sample .NET 8 template projects that contain
 
 - Simple Web API application
 - A Web API application with CQRS functionality

--- a/docs/workloads/azure/backend/netcore/quickstart/web_api_cqrs/create_project_netcore.md
+++ b/docs/workloads/azure/backend/netcore/quickstart/web_api_cqrs/create_project_netcore.md
@@ -31,12 +31,12 @@ keywords:
 ### Install the package
 
 
-Access Amido.Stacks.CQRS.Template package page in Nuget [here](https://www.nuget.org/packages/Amido.Stacks.Templates/)
+Access Amido.Stacks.Template package page in Nuget [here](https://www.nuget.org/packages/Amido.Stacks.Templates/)
 Copy and execute the command displayed in the page (if you want to get the latest version).
 For example
 
 ```bash title="Run the command to install the package"
-dotnet new install Amido.Stacks.CQRS.Templates
+dotnet new install Amido.Stacks.Templates
 ```
 
 Once installed, you obtain 7 templates that can be used

--- a/docs/workloads/azure/backend/netcore/requirments_netcore.md
+++ b/docs/workloads/azure/backend/netcore/requirments_netcore.md
@@ -40,7 +40,7 @@ values={[
         <div>
             <h5>Mandatory</h5>
             <ul>
-                <li><a href="https://dotnet.microsoft.com/en-us/download/dotnet/6.0">.NET 6 SDK</a> and Runtime 6.0.* or superior (for .NET 6 templates)</li>
+                <li><a href="https://dotnet.microsoft.com/en-us/download/dotnet/8.0">.NET 8 SDK</a> and Runtime 8.0.* or superior (for .NET 8 templates)</li>
                 <li><a href="https://aka.ms/cosmosdb-emulator">CosmosDB Emulator 2.4.5+</a></li>
             </ul>
             <h5>Optional</h5>
@@ -109,7 +109,7 @@ values={[
             <ul>
                 <li>homebrew</li>
                 <li>azure-cli: brew install azure-cli</li>
-                <li><a href="https://dotnet.microsoft.com/en-us/download/dotnet/6.0">.NET 6 SDK</a> 6.0.* or superior: brew cask install dotnet-sdk</li>
+                <li><a href="https://dotnet.microsoft.com/en-us/download/dotnet/8.0">.NET 8 SDK</a> 8.0.* or superior: brew cask install dotnet-sdk</li>
                 <li>
                     <a href="https://aka.ms/cosmosdb-emulator">CosmosDB Emulator 2.4.5+</a>: Currently the Cosmos emulator can only be run on Windows. If you have an Azure subscription, you are able to use the Azure version instead
                 </li>
@@ -130,5 +130,5 @@ values={[
 </Tabs>
 
 :::note
-The current version of Ensono Stacks are templates for .NET 6 (Current LTS, recommended).
+The current version of Ensono Stacks are templates for .NET 8 (Current LTS, recommended).
 :::


### PR DESCRIPTION
#### 📲 What

Update the version number in the documentation and code from .NET 6 to .NET 8 to accurately reflect the current version of the REST API application. This ensures that the documentation and code are aligned and up to date.

#### 🤔 Why
		
To ensure that the documentation and code are aligned and up to date.
		
#### 🛠 How
		
N/A

#### 👀 Evidence
		
N/A
		 
#### 🕵️ How to test

N/A

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
