### PR TITLE
chore(security): bumped vulnerable packages to mitigate path-to-regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,12 +1724,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-constant-elements": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.7.tgz",
-      "integrity": "sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==",
+      "version": "7.25.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.25.1.tgz",
+      "integrity": "sha512-SLV/giH/V4SmloZ6Dt40HjTGTAIkxn33TVIHxNGNvo8ezMhrxBkzisj4op1KZYPIOHFLqhv60OHvX+YRu4xbmQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.2.tgz",
+      "integrity": "sha512-4Z1WkhCSkX4KO0Fw5m/Vuc7Q3NxBG53NE5u59Rs96fWkMPZVSrzEPP16/Nk6cWb/shK7xXPndTmalJtw7twL/w==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.3",
@@ -2330,12 +2330,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/cssnano-preset": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2396,14 +2396,15 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@mdx-js/react": "^3.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
-      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.2.tgz",
+      "integrity": "sha512-D3KiQXOMA8+O0tqORBrTOEQyQxNIfPm9jEaJoALjjSjc2M/ZAWcUfPQEnwr2JB2TadHw2gqWgpZckQmrVWkytA==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -2416,9 +2417,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.2.tgz",
+      "integrity": "sha512-LHC540SGkeLfyT3RHK3gAMK6aS5TRqOD4R72BEU/DE2M/TY8WwEUAMY576UUc/oNJXv8pGhBmQB6N9p3pt8LQw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -2429,14 +2430,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
-      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.2.tgz",
+      "integrity": "sha512-ku3xO9vZdwpiMIVd8BzWV0DCqGEbCP5zs1iHfKX50vw6jX8vQo0ylYo1YJMZyz6e+JFJ17HYHT5FzVidz2IflA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2468,12 +2469,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
-      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.5.2.tgz",
+      "integrity": "sha512-Z+Xu3+2rvKef/YKTMxZHsEXp1y92ac0ngjDiExRdqGTmEKtCUpkbNYH8v5eXo5Ls+dnW88n6WTa+Q54kLOkwPg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.4.0",
+        "@docusaurus/types": "3.5.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2487,19 +2488,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
-      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.5.2.tgz",
+      "integrity": "sha512-R7ghWnMvjSf+aeNDH0K4fjyQnt5L0KzUEnUhmf1e3jZrv3wogeytZNN6n7X8yHcMsuZHPOrctQhXWnmxu+IRRg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
-        "cheerio": "^1.0.0-rc.12",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
+        "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2514,24 +2516,26 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
-      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.5.2.tgz",
+      "integrity": "sha512-Bt+OXn/CPtVqM3Di44vHjE7rPCEsRCB/DMo2qoOuozB9f7+lsdrHvD0QCHdBs0uhz6deYJDppAr2VgqybKPlVQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2550,16 +2554,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
-      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.5.2.tgz",
+      "integrity": "sha512-WzhHjNpoQAUz/ueO10cnundRz+VUtkjFhhaQ9jApyv1a46FPURO4cef89pyNIOMny1fjDz/NUN2z6Yi+5WUrCw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2573,14 +2577,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
-      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.5.2.tgz",
+      "integrity": "sha512-kBK6GlN0itCkrmHuCS6aX1wmoWc5wpd5KJlqQ1FyrF0cLDnvsYSnh7+ftdwzt7G6lGBho8lrVwkkL9/iQvaSOA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2594,14 +2598,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
-      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.5.2.tgz",
+      "integrity": "sha512-rjEkJH/tJ8OXRE9bwhV2mb/WP93V441rD6XnM6MIluu7rk8qg38iSxS43ga2V2Q/2ib53PcqbDEJDG/yWQRJhQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2613,14 +2617,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
-      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.2.tgz",
+      "integrity": "sha512-lm8XL3xLkTPHFKKjLjEEAHUrW0SZBSHBE1I+i/tmYMBsjCcUB5UJ52geS5PSiOCFVR74tbPGcPHEV/gaaxFeSA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2633,14 +2637,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
-      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.5.2.tgz",
+      "integrity": "sha512-QkpX68PMOMu10Mvgvr5CfZAzZQFx8WLlOiUQ/Qmmcl6mjGK6H21WLT5x7xDmcpCoKA/3CegsqIqBR+nA137lQg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2652,17 +2656,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
-      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.5.2.tgz",
+      "integrity": "sha512-DnlqYyRAdQ4NHY28TfHuVk414ft2uruP4QWCH//jzpHjqvKyXjj2fmDtI8RPUBh9K8iZKFMHRnLtzJKySPWvFA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2676,24 +2680,24 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
-      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.5.2.tgz",
+      "integrity": "sha512-3ihfXQ95aOHiLB5uCu+9PRy2gZCeSZoDcqpnDvf3B+sTrMvMTr8qRUzBvWkoIqc82yG5prCboRjk1SVILKx6sg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/plugin-debug": "3.4.0",
-        "@docusaurus/plugin-google-analytics": "3.4.0",
-        "@docusaurus/plugin-google-gtag": "3.4.0",
-        "@docusaurus/plugin-google-tag-manager": "3.4.0",
-        "@docusaurus/plugin-sitemap": "3.4.0",
-        "@docusaurus/theme-classic": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-search-algolia": "3.4.0",
-        "@docusaurus/types": "3.4.0"
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/plugin-content-blog": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/plugin-content-pages": "3.5.2",
+        "@docusaurus/plugin-debug": "3.5.2",
+        "@docusaurus/plugin-google-analytics": "3.5.2",
+        "@docusaurus/plugin-google-gtag": "3.5.2",
+        "@docusaurus/plugin-google-tag-manager": "3.5.2",
+        "@docusaurus/plugin-sitemap": "3.5.2",
+        "@docusaurus/theme-classic": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-search-algolia": "3.5.2",
+        "@docusaurus/types": "3.5.2"
       },
       "engines": {
         "node": ">=18.0"
@@ -2704,27 +2708,27 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
-      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.5.2.tgz",
+      "integrity": "sha512-XRpinSix3NBv95Rk7xeMF9k4safMkwnpSgThn0UNQNumKvmcIYjfkwfh2BhwYh/BxMXQHJ/PdmNh22TQFpIaYg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/plugin-content-blog": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/plugin-content-pages": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-translations": "3.5.2",
+        "@docusaurus/types": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
-        "infima": "0.2.0-alpha.43",
+        "infima": "0.2.0-alpha.44",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.26",
@@ -2744,18 +2748,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
-      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.5.2.tgz",
+      "integrity": "sha512-QXqlm9S6x9Ibwjs7I2yEDgsCocp708DrCrgHgKwg2n2AY0YQ6IjU0gAK35lHRLOvAoJUfCKpQAwUykB0R7+Eew==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/mdx-loader": "3.5.2",
+        "@docusaurus/module-type-aliases": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2769,24 +2770,25 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
-      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.5.2.tgz",
+      "integrity": "sha512-qW53kp3VzMnEqZGjakaV90sst3iN1o32PH+nawv1uepROO8aEGxptcq2R5rsv7aBShSRbZwIobdvSYKsZ5pqvA==",
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.5.2",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/plugin-content-docs": "3.5.2",
+        "@docusaurus/theme-common": "3.5.2",
+        "@docusaurus/theme-translations": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-validation": "3.5.2",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2805,9 +2807,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
-      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.5.2.tgz",
+      "integrity": "sha512-GPZLcu4aT1EmqSTmbdpVrDENGR2yObFEX8ssEFYTCiAIVc0EihNSdOIBTazUvgNqwvnoU1A8vIs1xyzc3LITTw==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -2818,9 +2820,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.2.tgz",
+      "integrity": "sha512-N6GntLXoLVUwkZw7zCxwy9QiuEXIcTVzA9AkmNw16oc0AP3SXLrMmDMMBIfgqwuKWa6Ox6epHol9kMtJqekACw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -2839,13 +2841,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
-      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.2.tgz",
+      "integrity": "sha512-33QvcNFh+Gv+C2dP9Y9xWEzMgf3JzrpL2nW9PopidiohS1nDcyknKRx2DWaFvyVTTYIkkABVSr073VTj/NITNA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2878,9 +2880,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
-      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.2.tgz",
+      "integrity": "sha512-i0AZjHiRgJU6d7faQngIhuHKNrszpL/SHQPgF1zH4H+Ij6E9NBYGy6pkcGWToIv7IVPbs+pQLh1P3whn0gWXVg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.0"
@@ -2898,14 +2900,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.2.tgz",
+      "integrity": "sha512-m+Foq7augzXqB6HufdS139PFxDC5d5q2QKZy8q0qYYvGdI6nnlNsGH4cIGsgBnV7smz+mopl3g4asbSDvMV0jA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/logger": "3.5.2",
+        "@docusaurus/utils": "3.5.2",
+        "@docusaurus/utils-common": "3.5.2",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4412,9 +4414,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.3.tgz",
-      "integrity": "sha512-2eoEz8mG4KHE+DzfrBTrCmDPxVXv7aZZWPojAJFtARpxxMO6lkos1dJ+XDCXdPvq7q3tpYWRi6xXmVQikejtpA==",
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.5.tgz",
+      "integrity": "sha512-lWvhdnc+aKOKx8jyA3bsdEgHzm/sglC4cYdMG4xSQyRiPLJVJtH/IVYZG3Hp6PkTEhQqhyVYkeP9z2IlcHJsWw==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -4801,9 +4803,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -4814,7 +4816,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -6559,9 +6561,9 @@
       }
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6923,37 +6925,37 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -6992,9 +6994,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {
@@ -7240,13 +7242,13 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -8670,9 +8672,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.43",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
-      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
+      "version": "0.2.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.44.tgz",
+      "integrity": "sha512-tuRkUSO/lB3rEhLJk25atwAjgLuzq070+pOW8XcvpHky/YbENnRRdPd85IBkyeTgttmOy5ah+yHYsK1HhUd4lQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10383,10 +10385,13 @@
       "license": "MIT"
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "license": "MIT"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -12922,9 +12927,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "license": "MIT",
       "dependencies": {
         "isarray": "0.0.1"
@@ -13849,12 +13854,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -14178,9 +14183,9 @@
       "license": "MIT"
     },
     "node_modules/react-json-view-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.4.0.tgz",
-      "integrity": "sha512-wh6F6uJyYAmQ4fK0e8dSQMEWuvTs2Wr3el3sLD9bambX1+pSWUVXIz1RFaoy3TI1mZ0FqdpKq9YgbgTTgyrmXA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.5.0.tgz",
+      "integrity": "sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -14244,7 +14249,7 @@
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
+        "path-to-regexp": "^1.9.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
@@ -14980,9 +14985,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/rtlcss": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.1.1.tgz",
-      "integrity": "sha512-/oVHgBtnPNcggP2aVXQjSy6N1mMAfHg4GSag0QtZBlD5bdDgAHwr4pydqJGd+SUCu9260+Pjqbjwtvu7EMH1KQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
+      "integrity": "sha512-FI+pHEn7Wc4NqKXMXFM+VAYKEj/mRIcW4h24YVwVtyjI+EqGrLc2Hx/Ny0lrZ21cBWU2goLy36eqMcNj3AQJig==",
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.1.1",
@@ -15198,9 +15203,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -15235,6 +15240,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
@@ -15272,7 +15286,7 @@
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "8.0.0",
         "range-parser": "1.2.0"
       }
     },
@@ -15299,10 +15313,13 @@
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-      "license": "MIT"
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.0.0.tgz",
+      "integrity": "sha512-GAWaqWlTjYK/7SVpIUA6CTxmcg65SP30sbjdCvyYReosRkk7Z/LyHWwkK3Vu0FcIi0FNTADUs4eh1AsU5s10cg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
@@ -15383,15 +15400,15 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"


### PR DESCRIPTION
#### 📲 What

Security update as of 2024-09-17:

- bumped path-to-regexp to mitigate CVE-2024-45296
- used `npm audit fix` to mitigate others

#### 🤔 Why
		
We are committed to resolving Critical, High and Medium vulnerabilities within a reasonable timeframe within Stacks to meet our obligations under ISO 27001, CyberEssentials Plus and numerous commitments to clients.
		
#### 🛠 How
		
Used `npm audit fix` to bump versions within ranges, then updated `path-to-regexp` as per instructions in GHSA-9wv6-86v2-598j.

#### 👀 Evidence
		
```
 $ npm run lint

> stacks@0.0.0 lint
> node_modules/.bin/markdownlint ./docs

[No Output]

```
		 
#### 🕵️ How to test

Run `npm start` to launch locally.

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [X] Passing any exploratory testing?
- [X] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
